### PR TITLE
fix: No fee estimate error handling

### DIFF
--- a/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheet.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheet.kt
@@ -351,6 +351,8 @@ object SendSheet {
 
         object OnNetworkFeeError : E()
 
+        object OnInsufficientBalance: E()
+
         data class OnNetworkFeeUpdated(
             @Redacted val targetAddress: String,
             val amount: BigDecimal,

--- a/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetHandler.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetHandler.kt
@@ -221,10 +221,10 @@ object SendSheetHandler {
             val address = wallet.addressFor(effect.address) ?: return@mapNotNull null
             if (wallet.containsAddress(address))
                 return@mapNotNull null
-
             val amount = Amount.create(effect.amount.toDouble(), wallet.unit)
             val networkFee = wallet.feeForSpeed(effect.transferSpeed)
-
+            null
+            /*
             try {
                 val data = wallet.estimateFee(address, amount, networkFee)
                 val fee = data.fee.toBigDecimal()
@@ -237,6 +237,7 @@ object SendSheetHandler {
                 logError("Failed get fee estimate", e)
                 E.OnNetworkFeeError
             }
+             */
         }
     }
 

--- a/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetHandler.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetHandler.kt
@@ -223,8 +223,7 @@ object SendSheetHandler {
                 return@mapNotNull null
             val amount = Amount.create(effect.amount.toDouble(), wallet.unit)
             val networkFee = wallet.feeForSpeed(effect.transferSpeed)
-            null
-            /*
+
             try {
                 val data = wallet.estimateFee(address, amount, networkFee)
                 val fee = data.fee.toBigDecimal()
@@ -232,12 +231,11 @@ object SendSheetHandler {
                 E.OnNetworkFeeUpdated(effect.address, effect.amount, fee, data)
             } catch (e: FeeEstimationError) {
                 logError("Failed get fee estimate", e)
-                E.OnNetworkFeeError
+                E.OnInsufficientBalance
             } catch (e: IllegalStateException) {
                 logError("Failed get fee estimate", e)
                 E.OnNetworkFeeError
             }
-             */
         }
     }
 

--- a/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetUpdate.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetUpdate.kt
@@ -891,6 +891,15 @@ object SendSheetUpdate : Update<M, E, F>, SendSheetUpdateSpec {
         return dispatch(effects(F.ShowSupportDialog(topic)))
     }
 
+    override fun onInsufficientBalance(model: M, event: E.OnInsufficientBalance): Next<M, F> {
+        return next(
+            model.copy(
+                feeEstimateFailed = true,
+                amountInputError = M.InputError.BalanceTooLow
+            )
+        )
+    }
+
     override fun onTransferFieldsUpdated(
         model: M,
         event: E.OnTransferFieldsUpdated

--- a/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetUpdateSpec.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/ui/send/SendSheetUpdateSpec.kt
@@ -48,6 +48,7 @@ interface SendSheetUpdateSpec {
         is SendSheet.E.OnExchangeRateUpdated -> onExchangeRateUpdated(model, event)
         is SendSheet.E.OnBalanceUpdated -> onBalanceUpdated(model, event)
         is SendSheet.E.OnNetworkFeeUpdated -> onNetworkFeeUpdated(model, event)
+        is SendSheet.E.OnInsufficientBalance -> onInsufficientBalance(model, event)
         is SendSheet.E.OnTransferSpeedChanged -> onTransferSpeedChanged(model, event)
         is SendSheet.E.OnTargetStringChanged -> onTargetStringChanged(model, event)
         is SendSheet.E.OnMemoChanged -> onMemoChanged(model, event)
@@ -134,4 +135,6 @@ interface SendSheetUpdateSpec {
     fun onDestinationTagFaqClicked(model: SendSheet.M, event: SendSheet.E): Next<SendSheet.M, SendSheet.F>
 
     fun onSendFaqClicked(model: SendSheet.M, event: SendSheet.E.OnSendFaqClicked): Next<SendSheet.M, SendSheet.F>
+
+    fun onInsufficientBalance(model: SendSheet.M, event: SendSheet.E.OnInsufficientBalance): Next<SendSheet.M,SendSheet.F>
 }


### PR DESCRIPTION
link to issue - https://bayes.atlassian.net/browse/W1-351
As discussed on meeting we do simple fix for now until we find the root of returning error. The fix removes check for estimate fee while typing because this endpoint returns error although it returns fee. When we press send the app should still caltulate fee and return alertDialog if we dont have enough assets.

 - update: Implemented Žan's suggestion for solving this issue