### PR TITLE
releasing 4.11.1.35

### DIFF
--- a/buildSrc/src/main/kotlin/brd/BrdRelease.kt
+++ b/buildSrc/src/main/kotlin/brd/BrdRelease.kt
@@ -41,7 +41,7 @@ object BrdRelease {
     private val engineering = ciTag?.get(2) ?: 1
 
     /** Build version. Increase for each new build. Maximum value: 999 */
-    private val build = ciTag?.lastOrNull() ?: 34
+    private val build = ciTag?.lastOrNull() ?: 35
 
     init {
         check(marketing in 0..99)


### PR DESCRIPTION
Release notes
W1-353 - new ERC20 tokens are not displayed after creating new or restoring old wallet
W1-384 - splash screen support on Android 12