### PR TITLE
feature/W1-451-frozen-from-bg

### DIFF
--- a/brd-android/app/src/main/java/com/breadwallet/breadbox/CoreBreadBox.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/breadbox/CoreBreadBox.kt
@@ -162,6 +162,7 @@ internal class CoreBreadBox(
         system = newSystem().also { system ->
             logDebug("Dispatching initial System values")
 
+            // This a hack to fix W1-451, see more in https://github.com/blockset-corp/walletkit/issues/362
             system.resume()
             system.resume()
 

--- a/brd-android/app/src/main/java/com/breadwallet/breadbox/CoreBreadBox.kt
+++ b/brd-android/app/src/main/java/com/breadwallet/breadbox/CoreBreadBox.kt
@@ -163,6 +163,7 @@ internal class CoreBreadBox(
             logDebug("Dispatching initial System values")
 
             system.resume()
+            system.resume()
 
             networkManager = NetworkManager(
                 system,


### PR DESCRIPTION
fixing problem with restoring walletkit.system from background